### PR TITLE
Add check for $tc keys

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -94,16 +94,26 @@ module.exports = {
     const content = [];
     return new Promise((resolve) => {
       async.eachSeries(filesCollection, (file, callback) => {
-        ssearch.find(file.content, /[$ ]t\(['`](.*)['`]\)/gi).then((res) => {
+        ssearch.find(file.content, /[$ ]tc?\(['`](.*)['`]\)/gi).then((res) => {
           if (res.length > 0) {
             res.forEach((r) => {
               let { text } = r;
+                           
               text = text.replace('$t(\'', 'i18nSTART###');
+              text = text.replace('$tc(\'', 'i18nSTART###');
+
               text = text.replace('$t(`', 'i18nSTART###');
+              text = text.replace('$tc(`', 'i18nSTART###');
+
               text = text.replace(' t(`', 'i18nSTART###');
+              text = text.replace(' tc(`', 'i18nSTART###');
+
               text = text.replace(' t(\'', 'i18nSTART###');
+              text = text.replace(' tc(\'', 'i18nSTART###');
+
               text = text.replace('\')', '###i18nEND');
               text = text.replace('`)', '###i18nEND');
+
               content.push({
                 line: r.line,
                 text: text.substring(text.lastIndexOf('i18nSTART###') + 12, text.lastIndexOf('###i18nEND')),


### PR DESCRIPTION
Hi! I noticed that this wouldn't match `$tc` for pluralized translations. I've added that functionality in!

I didn't add in `$n` or `$d` because those don't want string types.

I am currently working on making this tool also match the custom `v-t` directive and the `i18n` component.