### PR TITLE
Matching i18n component and v-t string literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ yarn add --dev vue-i18n-extract
 ```
 
 ## :smirk: The problem solved
-This module analyses code statically for key usages in ($t(''), t(''), $t(``), t(``), $tc(''), tc(''), $tc(``), tc(``)) and all the language files (ex. de_DE.js, en_EN.json, ...), in order to:
+This module analyses code statically for key usages in (ex. $t(''), $tc(''), ...) and all the language files (ex. de_DE.js, en_EN.json, ...), in order to:
 
 - [x] Report keys that are missing in the language files
 - [x] Report unused keys in the language files
@@ -134,6 +134,15 @@ t('key.static') and tc('key.static')
 - [x] template string:
 ```js
 $t((`key.template`) and $tc((`key.template`)
+```
+- [x] template i18n component:
+```js
+<i18n path="key.template.component">
+</i18n>
+```
+- [x] v-t directive with string literal (no path support to the component data):
+```js
+<p v-t="'key.directive.string'"></p>
 ```
 
 

--- a/demo/vue_files/ex3.vue
+++ b/demo/vue_files/ex3.vue
@@ -6,6 +6,9 @@
     <p>{{ $t('menu.paragraphs.p_a') }}</p>
     <p>{{ $t('menu.paragraphs.p_b') }}</p>
     <p>{{ $t('menu.paragraphs.p_c') }}</p>
+    <i18n path="link.a">
+      <a href="#">{{ $tc('link.b', 3) }}</a>
+    </i18n>
   </div>
 </template>
 

--- a/demo/vue_files/ex5/ex5.vue
+++ b/demo/vue_files/ex5/ex5.vue
@@ -6,6 +6,7 @@
     <p>{{ $t('test.paragraphs.p_a') }}</p>
     <p>{{ $t('test.paragraphs.p_b') }}</p>
     <p>{{ $t('test.paragraphs.p_c') }}</p>
+    <p v-t="'test.paragraphs.p_d'"></p>
   </div>
 </template>
 

--- a/src/__tests__/lib.test.js
+++ b/src/__tests__/lib.test.js
@@ -62,7 +62,7 @@ describe('Lib', () => {
     test('extract supported i18n strings from a collection of file paths', async () => {
       const filesCollection = lib.readVueFiles('./src/__tests__/test_demo_files/default/**/*.?(js|vue)');
       const results = await lib.extractI18nStringsFromFilesCollection(filesCollection);
-      expect(results.length).toEqual(9);
+      expect(results.length).toEqual(12);
     });
   });
 });

--- a/src/__tests__/test_demo_files/default/folder/file3.vue
+++ b/src/__tests__/test_demo_files/default/folder/file3.vue
@@ -1,2 +1,6 @@
 const text = t('test.a.b.f');
 const pluralText = tc('plural.a.b.f', 5);
+<i18n path="test.d.e.f">
+  <a>{{ $t('test.a.b.d') }}</a>
+</i18n>
+

--- a/src/__tests__/test_demo_files/default/folder/folder 2/file4.vue
+++ b/src/__tests__/test_demo_files/default/folder/folder 2/file4.vue
@@ -1,2 +1,3 @@
 const text = t('test.b.f.an');
 const pluralText = tc('plural.b.f.an', 4);
+<div v-t="'test.directive'"></div>


### PR DESCRIPTION
Hey there! As promised I've made some changes that match keys for the i18n component and for using the v-t directive.

Unfortunately, for now, the v-t directive support is limited to using it with a string literal. There are too many potential issues involved with booting up Vue, compiling the associated component and searching for a path match in the component's data.

I've also made some changes that make use of REGEX capture groups to find the desired key. Using this method there is no longer the need to use string replace methods to indicate the start and end of desired parts of the file. :tada: