### PR TITLE
API enchancement

### DIFF
--- a/src/library/models.ts
+++ b/src/library/models.ts
@@ -16,6 +16,6 @@ export interface I18NLanguage {
 }
 
 export interface I18NReport {
-  missingKeys: I18NItem[];
-  unusedKeys: I18NItem[];
+  missingKeys?: I18NItem[];
+  unusedKeys?: I18NItem[];
 }


### PR DESCRIPTION
I've extended vue-i18n-extract API.
Currently, `missingKeys` and `unsuedKeys` are reported together. Sometimes, I think that users want to control report output.
In vue-cli-plugin-i18n, I want to enable the user to customize reporting with CLI options (e.g. vue-cli-servie i18n:report --type='missing').

