### PR TITLE
Adjust source code parsing

### DIFF
--- a/src/library/file-operations-vue.ts
+++ b/src/library/file-operations-vue.ts
@@ -15,7 +15,7 @@ export function extractI18nItemsFromVueFiles (sourceFiles: SimpleFile[]): I18NIt
 }
 
 function extractMethodMatches (file: SimpleFile): I18NItem[] {
-  const methodRegExp: RegExp = /(?:[$ .]tc?)\(("|'|`)(.*?)\1/g;
+  const methodRegExp: RegExp = /(?:[$ .]tc?)\(\s*?("|'|`)(.*?)\1/g;
   return [ ...getMatches(file, methodRegExp, 2) ];
 }
 

--- a/src/library/file-operations-vue.ts
+++ b/src/library/file-operations-vue.ts
@@ -15,7 +15,7 @@ export function extractI18nItemsFromVueFiles (sourceFiles: SimpleFile[]): I18NIt
 }
 
 function extractMethodMatches (file: SimpleFile): I18NItem[] {
-  const methodRegExp: RegExp = /(?:\$tc?| tc?)\(("|'|`)(.*?)\1/g;
+  const methodRegExp: RegExp = /(?:[$ .]tc?)\(("|'|`)(.*?)\1/g;
   return [ ...getMatches(file, methodRegExp, 2) ];
 }
 

--- a/tests/unit/Api.spec.ts
+++ b/tests/unit/Api.spec.ts
@@ -32,7 +32,7 @@ describe('Api.ts', () => {
   it('function: parseVueFiles', () => {
     const src: string = path.resolve(__dirname, './fixtures/vue-files/**/*.?(js|vue)');
     const extractedI18NItems: I18NItem[] = api.parseVueFiles(src);
-    expect(extractedI18NItems).toHaveLength(14);
+    expect(extractedI18NItems).toHaveLength(15);
   });
 
   it('function: parseLanguageFiles', () => {

--- a/tests/unit/Api.spec.ts
+++ b/tests/unit/Api.spec.ts
@@ -32,7 +32,7 @@ describe('Api.ts', () => {
   it('function: parseVueFiles', () => {
     const src: string = path.resolve(__dirname, './fixtures/vue-files/**/*.?(js|vue)');
     const extractedI18NItems: I18NItem[] = api.parseVueFiles(src);
-    expect(extractedI18NItems).toHaveLength(13);
+    expect(extractedI18NItems).toHaveLength(14);
   });
 
   it('function: parseLanguageFiles', () => {

--- a/tests/unit/fixtures/vue-files/file1.js
+++ b/tests/unit/fixtures/vue-files/file1.js
@@ -1,3 +1,7 @@
 $t('header.titles.title_a');
 $tc('missing.a', 2);
 i18n.t('header.titles.title_a');
+i18n.t(
+  'header.titles.title_a',
+  2,
+);

--- a/tests/unit/fixtures/vue-files/file1.js
+++ b/tests/unit/fixtures/vue-files/file1.js
@@ -1,2 +1,3 @@
 $t('header.titles.title_a');
 $tc('missing.a', 2);
+i18n.t('header.titles.title_a');

--- a/tests/unit/library/file-operations-vue.spec.ts
+++ b/tests/unit/library/file-operations-vue.spec.ts
@@ -7,6 +7,6 @@ describe('file-operations-vue.ts', () => {
     const src: string = path.resolve(__dirname, '../fixtures/vue-files/**/*.?(js|vue)');
     const filesCollection: SimpleFile[] = readVueFiles(src);
     const results: I18NItem[] = extractI18nItemsFromVueFiles(filesCollection);
-    expect(results.length).toEqual(13);
+    expect(results.length).toEqual(14);
   });
 });

--- a/tests/unit/library/file-operations-vue.spec.ts
+++ b/tests/unit/library/file-operations-vue.spec.ts
@@ -7,6 +7,6 @@ describe('file-operations-vue.ts', () => {
     const src: string = path.resolve(__dirname, '../fixtures/vue-files/**/*.?(js|vue)');
     const filesCollection: SimpleFile[] = readVueFiles(src);
     const results: I18NItem[] = extractI18nItemsFromVueFiles(filesCollection);
-    expect(results.length).toEqual(14);
+    expect(results.length).toEqual(15);
   });
 });


### PR DESCRIPTION
In our project, we are importing i18n instance directly to some js modules and translating our stuff by `i18n.t` calls. Currently, this case is not handled by this package because it expects to see white space exactly before the call of `t`. I propose to add `.` to allowed chars to fix it.

Also, it some places we adding a new line before arguments of `t` call, but it breaks recognition of key usage. I'm fixing it in the second commit.