### PR TITLE
Allows parsing of YAML language files for reports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
   "dependencies": {
     "cli-table3": "^0.5.1",
     "dot-object": "^1.7.1",
-    "is-valid-glob": "^1.0.0",
-    "glob": "^7.1.3",
     "esm": "^3.2.13",
+    "glob": "^7.1.3",
+    "is-valid-glob": "^1.0.0",
+    "js-yaml": "^3.13.1",
     "yargs": "^13.2.2"
   },
   "devDependencies": {

--- a/src/library/read-files.ts
+++ b/src/library/read-files.ts
@@ -2,6 +2,7 @@ import isValidGlob from 'is-valid-glob';
 import glob from 'glob';
 import path from 'path';
 import fs from 'fs';
+import yaml from 'js-yaml';
 import { SimpleFile } from './models';
 
 // tslint:disable-next-line
@@ -37,7 +38,14 @@ export function readLangFiles (src: string): SimpleFile[] {
   return targetFiles.map((f) => {
     const langPath = path.resolve(process.cwd(), f);
 
-    const langModule = require(langPath);
+    let langModule;
+    const extension = langPath.substring(langPath.lastIndexOf('.')).toLowerCase();
+    if ( extension === '.yaml' || extension === '.yml') {
+      langModule = yaml.safeLoad(fs.readFileSync(langPath, 'utf8'));
+    } else {
+      langModule = require(langPath);
+    }
+    
     const { default: defaultImport } = langModule;
 
     const langObj = (defaultImport) ? defaultImport : langModule;


### PR DESCRIPTION
Checks for a file extension of .yml or .yaml, and parses to JSON.
This is work to fix: https://github.com/kazupon/vue-cli-plugin-i18n/issues/25

Primarily allows the use of: `vue-cli-service i18n:report --locales './src/i18n/locales/**/*.?(json|yaml|yml)'`