### PR TITLE
Fix extracting strings with escaped quotation marks

### DIFF
--- a/src/library/file-operations-vue.ts
+++ b/src/library/file-operations-vue.ts
@@ -15,7 +15,7 @@ export function extractI18nItemsFromVueFiles (sourceFiles: SimpleFile[]): I18NIt
 }
 
 function extractMethodMatches (file: SimpleFile): I18NItem[] {
-  const methodRegExp: RegExp = /(?:[$ .]tc?)\(\s*?("|'|`)(.*?)\1/g;
+  const methodRegExp: RegExp = /(?:[$ .]tc?)\(\s*?("|'|`)((?:[^\\]|\\.)*?)\1/g;
   return [ ...getMatches(file, methodRegExp, 2) ];
 }
 

--- a/src/library/file-operations-vue.ts
+++ b/src/library/file-operations-vue.ts
@@ -14,8 +14,31 @@ export function extractI18nItemsFromVueFiles (sourceFiles: SimpleFile[]): I18NIt
   }, []);
 }
 
+/**
+ * Extracts translation keys from methods such as `$t` and `$tc`.
+ *
+ * - **regexp pattern**: (?:[$ .]tc?)\(
+ *
+ *   **description**: Matches the sequence t( or tc(, optionally with either “$”, “.” or “ ” in front of it.
+ *
+ * - **regexp pattern**: (["'`])
+ *
+ *   **description**: 1. capturing group. Matches either “"”, “'”, or “`”.
+ *
+ * - **regexp pattern**: ((?:[^\\]|\\.)*?)
+ *
+ *   **description**: 2. capturing group. Matches anything except a backslash
+ *   *or* matches any backslash followed by any character (e.g. “\"”, “\`”, “\t”, etc.)
+ *
+ * - **regexp pattern**: \1
+ *
+ *   **description**: matches whatever was matched by capturing group 1 (e.g. the starting string character)
+ *
+ * @param file a file object
+ * @returns a list of translation keys found in `file`.
+ */
 function extractMethodMatches (file: SimpleFile): I18NItem[] {
-  const methodRegExp: RegExp = /(?:[$ .]tc?)\(\s*?("|'|`)((?:[^\\]|\\.)*?)\1/g;
+  const methodRegExp: RegExp = /(?:[$ .]tc?)\(\s*?(["'`])((?:[^\\]|\\.)*?)\1/g;
   return [ ...getMatches(file, methodRegExp, 2) ];
 }
 

--- a/tests/unit/Api.spec.ts
+++ b/tests/unit/Api.spec.ts
@@ -32,7 +32,7 @@ describe('Api.ts', () => {
   it('function: parseVueFiles', () => {
     const src: string = path.resolve(__dirname, './fixtures/vue-files/**/*.?(js|vue)');
     const extractedI18NItems: I18NItem[] = api.parseVueFiles(src);
-    expect(extractedI18NItems).toHaveLength(16);
+    expect(extractedI18NItems).toHaveLength(24);
   });
 
   it('function: parseLanguageFiles', () => {
@@ -58,6 +58,30 @@ describe('Api.ts', () => {
         path: 'missing.a',
       },
       {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'de_DE',
+        line: 9,
+        path: 'Don\\\'t leave me behind!',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'de_DE',
+        line: 10,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'de_DE',
+        line: 11,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'de_DE',
+        line: 12,
+        path: 'Backtick: \\\`',
+      },
+      {
         file: '/tests/unit/fixtures/vue-files/file2.js',
         language: 'de_DE',
         line: 2,
@@ -68,6 +92,30 @@ describe('Api.ts', () => {
         language: 'de_DE',
         line: 2,
         path: 'Missing',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'de_DE',
+        line: 3,
+        path: 'Don\\\'t leave me behind!',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'de_DE',
+        line: 4,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'de_DE',
+        line: 5,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'de_DE',
+        line: 6,
+        path: 'Backtick: \\\`',
       },
       {
         file: '/tests/unit/fixtures/vue-files/folder/file3.vue',
@@ -106,6 +154,30 @@ describe('Api.ts', () => {
         path: 'missing.a',
       },
       {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'en_EN',
+        line: 9,
+        path: 'Don\\\'t leave me behind!',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'en_EN',
+        line: 10,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'en_EN',
+        line: 11,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'en_EN',
+        line: 12,
+        path: 'Backtick: \\\`',
+      },
+      {
         file: '/tests/unit/fixtures/vue-files/file2.js',
         language: 'en_EN',
         line: 2,
@@ -116,6 +188,30 @@ describe('Api.ts', () => {
         language: 'en_EN',
         line: 2,
         path: 'Missing',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'en_EN',
+        line: 3,
+        path: 'Don\\\'t leave me behind!',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'en_EN',
+        line: 4,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'en_EN',
+        line: 5,
+        path: 'Early ',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file3.vue',
+        language: 'en_EN',
+        line: 6,
+        path: 'Backtick: \\\`',
       },
       {
         file: '/tests/unit/fixtures/vue-files/folder/file3.vue',

--- a/tests/unit/Api.spec.ts
+++ b/tests/unit/Api.spec.ts
@@ -32,7 +32,7 @@ describe('Api.ts', () => {
   it('function: parseVueFiles', () => {
     const src: string = path.resolve(__dirname, './fixtures/vue-files/**/*.?(js|vue)');
     const extractedI18NItems: I18NItem[] = api.parseVueFiles(src);
-    expect(extractedI18NItems).toHaveLength(24);
+    expect(extractedI18NItems).toHaveLength(26);
   });
 
   it('function: parseLanguageFiles', () => {
@@ -80,6 +80,18 @@ describe('Api.ts', () => {
         language: 'de_DE',
         line: 12,
         path: 'Backtick: \\\`',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'de_DE',
+        line: 13,
+        path: 'Optimistic match 1',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'de_DE',
+        line: 14,
+        path: 'Optimistic match 2',
       },
       {
         file: '/tests/unit/fixtures/vue-files/file2.js',
@@ -176,6 +188,18 @@ describe('Api.ts', () => {
         language: 'en_EN',
         line: 12,
         path: 'Backtick: \\\`',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'en_EN',
+        line: 13,
+        path: 'Optimistic match 1',
+      },
+      {
+        file: '/tests/unit/fixtures/vue-files/file1.js',
+        language: 'en_EN',
+        line: 14,
+        path: 'Optimistic match 2',
       },
       {
         file: '/tests/unit/fixtures/vue-files/file2.js',

--- a/tests/unit/fixtures/vue-files/file1.js
+++ b/tests/unit/fixtures/vue-files/file1.js
@@ -6,3 +6,7 @@ i18n.t(
   'header.titles.title_a',
   2,
 );
+$t('Don\'t leave me behind!');
+$t('Early ' string termination');
+$t("Early " string termination");
+$t(`Backtick: \``);

--- a/tests/unit/fixtures/vue-files/file1.js
+++ b/tests/unit/fixtures/vue-files/file1.js
@@ -10,3 +10,10 @@ $t('Don\'t leave me behind!');
 $t('Early ' string termination');
 $t("Early " string termination");
 $t(`Backtick: \``);
+.t("Optimistic match 1")
+ t("Optimistic match 2")
+
+// False positive. Should not produce a match.
+gt("FALSE POSITIVE 1")
+// False positive. Should not produce a match.
+;t("FALSE POSITIVE 2")

--- a/tests/unit/fixtures/vue-files/file3.vue
+++ b/tests/unit/fixtures/vue-files/file3.vue
@@ -1,2 +1,6 @@
-const test = $t('Key As Fallback');
-const test = $t('Missing');
+const test1 = $t('Key As Fallback');
+const test2 = $t('Missing');
+const test3 = $t('Don\'t leave me behind!');
+const test4 = $t('Early ' string termination');
+const test5 = $t("Early " string termination");
+const test6 = $t(`Backtick: \``);

--- a/tests/unit/library/file-operations-vue.spec.ts
+++ b/tests/unit/library/file-operations-vue.spec.ts
@@ -3,10 +3,70 @@ import { SimpleFile, I18NItem } from '@/library/models';
 import path from 'path';
 
 describe('file-operations-vue.ts', () => {
-  it('Extract supported i18n strings from a collection of file paths', () => {
+  it('extracts supported i18n strings from a collection of file paths', () => {
     const src: string = path.resolve(__dirname, '../fixtures/vue-files/**/*.?(js|vue)');
     const filesCollection: SimpleFile[] = readVueFiles(src);
     const results: I18NItem[] = extractI18nItemsFromVueFiles(filesCollection);
     expect(results.length).toEqual(26);
+  });
+
+  it('extracts translation keys from methods correctly', () => {
+    const testFiles = [
+      {
+        content: `$t('Natural-language key with spaces')`,
+        translationKey: 'Natural-language key with spaces',
+        fileName: '',
+        path: ''
+      },
+      {
+        content: `$t('path.without.spaces')`,
+        translationKey: 'path.without.spaces',
+        fileName: '',
+        path: ''
+      },
+      {
+        content: `$t('Don\\'t leave me behind!')`,
+        translationKey: 'Don\\\'t leave me behind!',
+        fileName: '',
+        path: ''
+      },
+      {
+        content: `$t('Early ' string termination')`,
+        translationKey: 'Early ',
+        fileName: '',
+        path: ''
+      },
+      {
+        content: `$t("Early " string termination")`,
+        translationKey: 'Early ',
+        fileName: '',
+        path: ''
+      },
+      {
+        content: `$t(\`Escaped backtick: \\\`\`)`,
+        translationKey: 'Escaped backtick: \\\`',
+        fileName: '',
+        path: ''
+      },
+      {
+        content: `$t('Nested "quotes"')`,
+        translationKey: 'Nested "quotes"',
+        fileName: '',
+        path: ''
+      },
+      {
+        content: `$t(
+          'Argument on new line'
+        )`,
+        translationKey: 'Argument on new line',
+        fileName: '',
+        path: ''
+      },
+    ]
+
+    const results = extractI18nItemsFromVueFiles(testFiles);
+    for (let i = 0; i < results.length; i++) {
+      expect(testFiles[i].translationKey).toBe(results[i].path)
+    }
   });
 });

--- a/tests/unit/library/file-operations-vue.spec.ts
+++ b/tests/unit/library/file-operations-vue.spec.ts
@@ -7,6 +7,6 @@ describe('file-operations-vue.ts', () => {
     const src: string = path.resolve(__dirname, '../fixtures/vue-files/**/*.?(js|vue)');
     const filesCollection: SimpleFile[] = readVueFiles(src);
     const results: I18NItem[] = extractI18nItemsFromVueFiles(filesCollection);
-    expect(results.length).toEqual(16);
+    expect(results.length).toEqual(24);
   });
 });

--- a/tests/unit/library/file-operations-vue.spec.ts
+++ b/tests/unit/library/file-operations-vue.spec.ts
@@ -7,6 +7,6 @@ describe('file-operations-vue.ts', () => {
     const src: string = path.resolve(__dirname, '../fixtures/vue-files/**/*.?(js|vue)');
     const filesCollection: SimpleFile[] = readVueFiles(src);
     const results: I18NItem[] = extractI18nItemsFromVueFiles(filesCollection);
-    expect(results.length).toEqual(24);
+    expect(results.length).toEqual(26);
   });
 });


### PR DESCRIPTION
Fixes #61.

The changes in this MR fix a bug preventing correct translation string extraction for strings containing escaped string termination characters (e.g. `$t("Hello \"buddy\".")`).

## Changes

- Changes the regexp in `extractMethodMatches` for the second capture group from `.` to `(?:[^\\]|\\.)`:

  `[^\\]`: match anything except a backslash

  `\\.`: match backslashes followed by any character

- Adds a couple of tests to ensure the content of calls to `$t(…)`, etc. are extracted correctly