### PR TITLE
ignore case when matching i18n tag

### DIFF
--- a/src/report-command/vue-files.ts
+++ b/src/report-command/vue-files.ts
@@ -64,7 +64,7 @@ function* getMatches (file: SimpleFile, regExp: RegExp, captureGroup = 1): Itera
 }
 
 function extractComponentMatches (file: SimpleFile): I18NItem[] {
-  const componentRegExp = /(?:<i18n|<I18N)(?:.|\n)*?(?:[^:]path=("|'))(.*?)\1/g;
+  const componentRegExp = /(?:<i18n)(?:.|\n)*?(?:[^:]path=("|'))(.*?)\1/gi;
   return [ ...getMatches(file, componentRegExp, 2) ];
 }
 

--- a/tests/unit/fixtures/expected-values.ts
+++ b/tests/unit/fixtures/expected-values.ts
@@ -110,8 +110,28 @@ export const expectedFromParsedVueFiles = [
     file: '/tests/unit/fixtures/vue-files/folder/file3.vue'
   },
   {
+    path: 'missing.e',
+    line: 7,
+    file: '/tests/unit/fixtures/vue-files/folder/file3.vue'
+  },
+  {
+    path: 'missing.f',
+    line: 10,
+    file: '/tests/unit/fixtures/vue-files/folder/file3.vue'
+  },
+  {
     path: 'header.paragraphs.p_a',
     line: 3,
+    file: '/tests/unit/fixtures/vue-files/folder/file3.vue'
+  },
+  {
+    path: 'header.paragraphs.p_b',
+    line: 6,
+    file: '/tests/unit/fixtures/vue-files/folder/file3.vue'
+  },
+  {
+    path: 'header.paragraphs.p_c',
+    line: 9,
     file: '/tests/unit/fixtures/vue-files/folder/file3.vue'
   },
   {

--- a/tests/unit/fixtures/vue-files/folder/file3.vue
+++ b/tests/unit/fixtures/vue-files/folder/file3.vue
@@ -3,4 +3,9 @@ const pluralText = tc('missing.c', 5);
 <i18n path="header.paragraphs.p_a">
   <a>{{ $t('missing.d') }}</a>
 </i18n>
-
+<I18n path="header.paragraphs.p_b">
+  <a>{{ $t('missing.e') }}</a>
+</I18n>
+<I18N path="header.paragraphs.p_c">
+  <a>{{ $t('missing.f') }}</a>
+</I18N>


### PR DESCRIPTION
This PR ignores case when scanning for i18n component tags. Keys declared within `path` prop will be detected for each of the following:

```
<i18n path="key" />
<I18n path="key" />
<I18N path="key" />
```