### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@
 Install with yarn:
 
 ```bash
-yarn add vue-i18-extract --dev
+yarn add vue-i18n-extract --dev
 ```
 
 Install with npm:
 
 ```bash
-npm install --save-dev vue-i18-extract
+npm install --save-dev vue-i18n-extract
 ```
 
 <h2>Introduction</h2>


### PR DESCRIPTION
When I tried to `yarn add` as per Readme, I got the following error 😄

```
error An unexpected error occurred: "https://registry.yarnpkg.com/vue-i18-extract: Not found".
```