### PR TITLE
Use languageFile.path which is already resolved (Fix #102)

### DIFF
--- a/src/report-command/language-files.ts
+++ b/src/report-command/language-files.ts
@@ -72,7 +72,7 @@ export function writeMissingToLanguage (resolvedLanguageFiles: string, missingKe
     });
 
     const fileExtension = languageFile.fileName.substring(languageFile.fileName.lastIndexOf('.') + 1);
-    const filePath = path.resolve(process.cwd(), languageFile.fileName);
+    const filePath = languageFile.path;
     const stringifiedContent = JSON.stringify(languageFileContent, null, 2);
 
     if (fileExtension === 'json') {


### PR DESCRIPTION
filePath was not resolving to the absolute path, but languageFile.path is already resolved so I was able to just switch to that. Add works as expected now. Addresses #102 