### PR TITLE
Added an option to override the DotObject separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Use if you want to add missing keys into your json language files.,
 
 -d, --dynamic,
 Use if you want to ignore dynamic keys false-positive. Use it 2 times to get dynamic keys report',
+
+-s, --separator,
+Use if you want to override the separator used when parsing locale identifiers. Default is `.`
 ```
 
 Examples

--- a/bin/vue-i18n-extract.js
+++ b/bin/vue-i18n-extract.js
@@ -34,6 +34,10 @@ program
     increaseDynamic,
     0
   )
+  .option(
+    '-s, --separator <separator>',
+    'Use if you want to override the separator used when parsing locale identifiers. Default is `.`'
+  )
   .action(reportCommand);
 
 program.parseAsync(process.argv);

--- a/src/report-command/index.ts
+++ b/src/report-command/index.ts
@@ -1,16 +1,17 @@
 import path from 'path';
+import Dot from 'dot-object';
 
 import { ReportOptions, I18NReport } from '../types';
 import { parseVueFiles } from './vue-files';
 import { parseLanguageFiles, writeMissingToLanguage } from './language-files';
 import { extractI18NReport, VueI18NExtractReportTypes, writeReportToFile } from './report';
 
-export function createI18NReport (vueFiles: string, languageFiles: string, command: ReportOptions): I18NReport {
+export function createI18NReport (vueFiles: string, languageFiles: string, command: ReportOptions, dot: DotObject.Dot = Dot): I18NReport {
   const resolvedVueFiles = path.resolve(process.cwd(), vueFiles);
   const resolvedLanguageFiles = path.resolve(process.cwd(), languageFiles);
 
   const parsedVueFiles = parseVueFiles(resolvedVueFiles);
-  const parsedLanguageFiles = parseLanguageFiles(resolvedLanguageFiles);
+  const parsedLanguageFiles = parseLanguageFiles(resolvedLanguageFiles, dot);
 
   const reportType = command.dynamic ? VueI18NExtractReportTypes.All : (VueI18NExtractReportTypes.Missing + VueI18NExtractReportTypes.Unused);
 
@@ -20,7 +21,8 @@ export function createI18NReport (vueFiles: string, languageFiles: string, comma
 export async function reportCommand (command: ReportOptions): Promise<void> {
   const { vueFiles, languageFiles, output, add, dynamic } = command;
 
-  const report = createI18NReport(vueFiles, languageFiles, command);
+  const dot = typeof command.separator === 'string' ? new Dot(command.separator) : Dot
+  const report = createI18NReport(vueFiles, languageFiles, command, dot);
 
   if (report.missingKeys) console.info('missing keys: '), console.table(report.missingKeys);
   if (report.unusedKeys) console.info('unused keys: '), console.table(report.unusedKeys);
@@ -33,7 +35,7 @@ export async function reportCommand (command: ReportOptions): Promise<void> {
 
   if (add && report.missingKeys && report.missingKeys.length > 0) {
     const resolvedLanguageFiles = path.resolve(process.cwd(), languageFiles);
-    writeMissingToLanguage(resolvedLanguageFiles, report.missingKeys);
+    writeMissingToLanguage(resolvedLanguageFiles, report.missingKeys, dot);
     console.log('The missing keys have been added to your languages files');
   }
 }

--- a/src/report-command/language-files.ts
+++ b/src/report-command/language-files.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import glob from 'glob';
-import dot from 'dot-object';
+import Dot from 'dot-object';
 import yaml from 'js-yaml';
 import isValidGlob from 'is-valid-glob';
 import { SimpleFile, I18NLanguage, I18NItem } from '../types';
@@ -39,7 +39,7 @@ function readLangFiles (src: string): SimpleFile[] {
   });
 }
 
-function extractI18nItemsFromLanguageFiles (languageFiles: SimpleFile[]): I18NLanguage {
+function extractI18nItemsFromLanguageFiles (languageFiles: SimpleFile[], dot: DotObject.Dot = Dot): I18NLanguage {
   return languageFiles.reduce((accumulator, file) => {
     const language = file.fileName.substring(file.fileName.lastIndexOf('/') + 1, file.fileName.lastIndexOf('.'));
 
@@ -60,7 +60,7 @@ function extractI18nItemsFromLanguageFiles (languageFiles: SimpleFile[]): I18NLa
   }, {});
 }
 
-export function writeMissingToLanguage (resolvedLanguageFiles: string, missingKeys: I18NItem[]): void {
+export function writeMissingToLanguage (resolvedLanguageFiles: string, missingKeys: I18NItem[], dot: DotObject.Dot = Dot): void {
   const languageFiles = readLangFiles(resolvedLanguageFiles);
   languageFiles.forEach(languageFile => {
     const languageFileContent = JSON.parse(languageFile.content);
@@ -87,7 +87,7 @@ export function writeMissingToLanguage (resolvedLanguageFiles: string, missingKe
   });
 }
 
-export function parseLanguageFiles (languageFilesPath: string): I18NLanguage {
+export function parseLanguageFiles (languageFilesPath: string, dot: DotObject.Dot = Dot): I18NLanguage {
   const filesList = readLangFiles(languageFilesPath);
-  return extractI18nItemsFromLanguageFiles(filesList);
+  return extractI18nItemsFromLanguageFiles(filesList, dot);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type ReportOptions = {
   output?: string;
   add?: boolean;
   dynamic?: number;
+  separator?: string;
 }
 
 export type SimpleFile = {


### PR DESCRIPTION
My team passes English strings with sentences as the identifiers in some locations. This PR allows us to override the separator used with the DotObject library so our sentences aren't picked up as nested identifiers.