### PR TITLE
fix: invalid js when generating config file

### DIFF
--- a/src/init-command/index.ts
+++ b/src/init-command/index.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 const configFile = `
 module.exports = {
   vueFilesPath: './', // The Vue.js file(s) you want to extract i18n strings from. It can be a path to a folder or to a file. It accepts glob patterns. (ex. *, ?, (pattern|pattern|pattern)
-  languageFilesPath: './', The language file(s) you want to compare your Vue.js file(s) to. It can be a path to a folder or to a file. It accepts glob patterns (ex. *, ?, (pattern|pattern|pattern)
+  languageFilesPath: './', // The language file(s) you want to compare your Vue.js file(s) to. It can be a path to a folder or to a file. It accepts glob patterns (ex. *, ?, (pattern|pattern|pattern)
   options: {
     output: false, // false | string => Use if you want to create a json file out of your report. (ex. output.json)
     add: false, // false | true => Use if you want to add missing keys into your json language files.

--- a/tests/unit/init-command/index.spec.ts
+++ b/tests/unit/init-command/index.spec.ts
@@ -5,7 +5,7 @@ import { initCommand } from '@/init-command';
 const configFile = `
 module.exports = {
   vueFilesPath: './', // The Vue.js file(s) you want to extract i18n strings from. It can be a path to a folder or to a file. It accepts glob patterns. (ex. *, ?, (pattern|pattern|pattern)
-  languageFilesPath: './', The language file(s) you want to compare your Vue.js file(s) to. It can be a path to a folder or to a file. It accepts glob patterns (ex. *, ?, (pattern|pattern|pattern)
+  languageFilesPath: './', // The language file(s) you want to compare your Vue.js file(s) to. It can be a path to a folder or to a file. It accepts glob patterns (ex. *, ?, (pattern|pattern|pattern)
   options: {
     output: false, // false | string => Use if you want to create a json file out of your report. (ex. output.json)
     add: false, // false | true => Use if you want to add missing keys into your json language files.


### PR DESCRIPTION
Noticed that the auto generated config file via `yarn run vue-i18n-extract init` was producing invalid javascript due to missing opening comment section.