### PR TITLE
Added an option to override the DotObject separator (fix merge conflicts and update code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Use if you want to ignore dynamic keys false-positive. Use it 2 times to get dyn
 
 -ci,
 The process will exit with exitCode=1 if at least one translation-key is missing (useful especially if it is part of a CI pipeline).',
+
+-s, --separator,
+Use if you want to override the separator used when parsing locale identifiers. Default is `.`,
 ```
 
 Examples

--- a/bin/vue-i18n-extract.js
+++ b/bin/vue-i18n-extract.js
@@ -50,6 +50,10 @@ program
     '-ci --ci',
     'The process will exit with exitCode=1 if at least one translation-key is missing (useful expecially if it is part of a CI pipeline).',
   )
+  .option(
+    '-s, --separator <separator>',
+    'Use if you want to override the separator used when parsing locale identifiers. Default is `.`'
+  )
   .action(reportCommand);
 
 

--- a/src/report-command/language-files.ts
+++ b/src/report-command/language-files.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import glob from 'glob';
-import dot from 'dot-object';
+import Dot from 'dot-object';
 import yaml from 'js-yaml';
 import isValidGlob from 'is-valid-glob';
 import { LanguageFile, I18NLanguage, I18NItem } from '../types';
@@ -39,7 +39,7 @@ function readLangFiles (src: string): LanguageFile[] {
   });
 }
 
-function extractI18nItemsFromLanguageFiles (languageFiles: LanguageFile[]): I18NLanguage {
+function extractI18nItemsFromLanguageFiles (languageFiles: LanguageFile[], dot: DotObject.Dot = Dot): I18NLanguage {
   return languageFiles.reduce((accumulator, file) => {
     const language = file.fileName.substring(file.fileName.lastIndexOf('/') + 1, file.fileName.lastIndexOf('.'));
 
@@ -68,7 +68,7 @@ export class LanguageFileUpdater {
     this.languageFiles = readLangFiles(path.resolve(process.cwd(), languageFiles));
   }
 
-  addMissingKeys(missingKeys: I18NItem[]): void {
+  addMissingKeys(missingKeys: I18NItem[], dot: DotObject.Dot = Dot): void {
     this.hasChanges = true;
     this.languageFiles.forEach(languageFile => {
       missingKeys.forEach(item => {
@@ -124,7 +124,7 @@ class FileAccessLayer {
   // TODO: Move reading into this class
 }
 
-export function parseLanguageFiles (languageFilesPath: string): I18NLanguage {
+export function parseLanguageFiles (languageFilesPath: string, dot: DotObject.Dot = Dot): I18NLanguage {
   const filesList = readLangFiles(languageFilesPath);
-  return extractI18nItemsFromLanguageFiles(filesList);
+  return extractI18nItemsFromLanguageFiles(filesList, dot);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type ReportOptions = {
   remove?: boolean;
   dynamic?: number;
   ci?: boolean;
+  separator?: string;
 }
 
 export type LanguageFile = {

--- a/tests/unit/report-command/language-files.spec.ts
+++ b/tests/unit/report-command/language-files.spec.ts
@@ -8,7 +8,7 @@ import { languageFiles } from '../fixtures/resolved-sources';
 describe('file: report-command/language-files', () => {
   describe('function: parseLanguageFiles', () => {
     it('Parse the file glob into and I18NLanguage object', () => {
-      const results = parseLanguageFiles(languageFiles);
+      const results = parseLanguageFiles(languageFiles, dot);
       expect(results).toEqual(expectedFromParsedLanguageFiles);
     });
 
@@ -35,7 +35,7 @@ describe('file: report-command/language-files', () => {
       const dotStrSpy = jest.spyOn(dot, 'str');
       const dotDeleteSpy = jest.spyOn(dot, 'delete');
       const updater = new LanguageFileUpdater(languageFiles);
-      updater.addMissingKeys(expectedI18NReport.missingKeys);
+      updater.addMissingKeys(expectedI18NReport.missingKeys, dot);
       updater.removeUnusedKeys(expectedI18NReport.unusedKeys);
       expect(updater.hasChanges).toBe(true);
       updater.writeChanges();


### PR DESCRIPTION
I have resumed the existing PR by fixing merge conflicts and updated code.
I have tested and when separator option is not given it works as the original and when separator is given (tested with  @) it works as expected and do not created nested strings. 